### PR TITLE
hide book card tooltip

### DIFF
--- a/src/components/publications/cardBook.css
+++ b/src/components/publications/cardBook.css
@@ -54,3 +54,9 @@
 .popover[x-placement^=left]>.popover-arrow:after {
   border-left-color: black;
 }
+
+@media (max-width: 991px) {
+  #popover-basic {
+    display: none;
+  }
+}


### PR DESCRIPTION
hide book card tooltip  for devices less than 991px screen width